### PR TITLE
Remove border from input elements when on focus

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -466,6 +466,8 @@ section {
 .email:focus,
 .msg:focus {
   transform: scale(1.05);
+  border: none;
+  outline: none;
 }
 
 .send {
@@ -573,6 +575,7 @@ section {
     width: 100%;
     display: flex;
     margin: 0;
+    border-radius: 16px;
     overflow: hidden;
   }
 


### PR DESCRIPTION
I removed the unwanted black border on the inputs when on focus. I also made the desktop project image animations to retain the border-radius while the image zooms in.